### PR TITLE
Harden Docker build, add .dockerignore, and update deployment docs for /partner2 basePath

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Dependencies and build output
+node_modules
+.next
+
+# VCS and docs
+.git
+.gitignore
+*.md
+
+# Environment and secret material
+.env
+.env.*
+!.env.example
+
+# Local tooling artifacts
+*.log
+coverage
+reports
+*.har

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -39,7 +39,7 @@ Edit `.env.production` with your production values:
 
 ```bash
 NODE_ENV=production
-NEXT_PUBLIC_APP_URL=https://yourdomain.com
+NEXT_PUBLIC_APP_URL=https://yourdomain.com/partner2
 NEXT_PUBLIC_ENABLE_ANALYTICS=true
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
 NEXT_PUBLIC_SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
@@ -63,10 +63,9 @@ Vercel is the easiest way to deploy Next.js applications.
 > the live URL will be `https://your-project.vercel.app/partner2`.  
 > Set `NEXT_PUBLIC_APP_URL` to that full URL (including `/partner2`).
 
-A `vercel.json` is already included in the repository with sensible defaults.  
-After deploying, update `NEXT_PUBLIC_APP_URL` in the Vercel dashboard (or CLI)
-to replace the placeholder `your-project.vercel.app` with your actual Vercel
-project URL (or custom domain).
+A `vercel.json` is already included in the repository with build defaults.  
+Set `NEXT_PUBLIC_APP_URL` in the Vercel dashboard (or CLI) for each environment
+(production/preview/development) so URLs always include `/partner2`.
 
 #### Option 1: Deploy via CLI
 
@@ -251,11 +250,12 @@ version: '3.8'
 services:
   app:
     build: .
+    env_file:
+      - .env.production
     environment:
       - NODE_ENV=production
       - PORT=3112
       - HOSTNAME=0.0.0.0
-      - NEXT_PUBLIC_APP_URL=https://yourdomain.com/partner2
     restart: unless-stopped
     networks:
       - app-network
@@ -279,10 +279,18 @@ networks:
     driver: bridge
 ```
 
-Example NGINX `location` block to proxy `/partner2`:
+> Ensure `.env.production` contains `NEXT_PUBLIC_APP_URL=https://yourdomain.com/partner2`.
+
+Example NGINX `location` blocks to proxy `/partner2`:
 
 ```nginx
-location /partner2 {
+# Redirect exact `/partner2` to `/partner2/` to avoid relative-path issues
+location = /partner2 {
+    return 301 /partner2/;
+}
+
+# Proxy all `/partner2/...` paths (without matching `/partner23`, etc.)
+location ^~ /partner2/ {
     proxy_pass         http://app:3112;
     proxy_set_header   Host $host;
     proxy_set_header   X-Real-IP $remote_addr;

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY package*.json ./
 COPY next.config.* ./
 COPY tsconfig.* ./
 COPY postcss.config.* ./
+COPY tailwind.config.* ./
 COPY eslint.config.* ./
 COPY public ./public
 COPY src ./src

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,15 @@ RUN npm ci
 FROM node:20-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+
+# Copy only build inputs (avoid accidentally copying local secrets like .env*)
+COPY package*.json ./
+COPY next.config.* ./
+COPY tsconfig.* ./
+COPY postcss.config.* ./
+COPY eslint.config.* ./
+COPY public ./public
+COPY src ./src
 
 # Produce a standalone Next.js bundle (see next.config.ts output:'standalone')
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/README.md
+++ b/README.md
@@ -495,11 +495,15 @@ WCAG 2.1 AA compliant:
    (e.g. `https://my-project.vercel.app/partner2`).
 3. The app will be accessible at `https://your-project.vercel.app/partner2`.
 
-> A `vercel.json` is included in the repository with sensible defaults.
+> A `vercel.json` is included in the repository with sensible build defaults.
+> Configure `NEXT_PUBLIC_APP_URL` in your Vercel project environment variables.
 
 ### Option 2 — Docker
 
 ```bash
+# Create production env file and set NEXT_PUBLIC_APP_URL with /partner2
+cp .env.example .env.production
+
 # Build and run with Docker Compose
 docker compose up -d --build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,13 @@ services:
     container_name: partner2-dashboard
     ports:
       - "3112:3112"
+    # Copy .env.example → .env.production and update values before deploying
+    env_file:
+      - .env.production
     environment:
-      - NODE_ENV=production
-      - PORT=3112
-      - HOSTNAME=0.0.0.0
-      # Copy .env.example → .env.production and update these values before deploying
-      - NEXT_PUBLIC_APP_URL=http://localhost:3112/partner2
+      NODE_ENV: production
+      PORT: 3112
+      HOSTNAME: 0.0.0.0
     restart: unless-stopped
     networks:
       - app-network

--- a/vercel.json
+++ b/vercel.json
@@ -3,8 +3,5 @@
   "buildCommand": "npm run build",
   "installCommand": "npm ci",
   "outputDirectory": ".next",
-  "regions": ["syd1"],
-  "env": {
-    "NEXT_PUBLIC_APP_URL": "https://your-project.vercel.app/partner2"
-  }
+  "regions": ["syd1"]
 }


### PR DESCRIPTION
### Motivation

- Prevent accidental inclusion of local secrets into images and clarify the required production base-path `/partner2` for deployments.
- Make container builds more deterministic by copying only necessary build inputs and documenting recommended runtime env setup.

### Description

- Add `.dockerignore` to exclude `node_modules`, `.next`, `.env*`, VCS files and other local artifacts from Docker context.
- Modify `Dockerfile` to avoid copying the entire repository into the builder stage and instead copy only explicit build inputs (`package*.json`, `next.config.*`, `tsconfig.*`, `postcss.config.*`, `eslint.config.*`, `public`, `src`) to reduce risk of leaking secrets and speed builds.
- Update `docker-compose.yml` to use an `env_file: .env.production`, normalize environment variable formatting, and add a note to create `.env.production` with `NEXT_PUBLIC_APP_URL` including `/partner2`.
- Remove the embedded `NEXT_PUBLIC_APP_URL` from `vercel.json` so environment URLs are set per-deployment, and update `README.md` and `DEPLOYMENT.md` with clearer instructions about the `/partner2` base-path, NGINX proxy examples (exact-path redirect and `^~` prefix), and other deploy notes.

### Testing

- Ran `npm ci` and `npm run build` locally and in CI, and the Next.js production build completed successfully.
- Built the Docker image with `docker build .` and ran `docker compose up -d --build` locally to verify the container starts and serves under `/partner2`, and both succeeded.
- Ran `npm test` and `npm run lint` locally; the test suite and linting passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b394abbfc883239386a27577f5042f)