### PR TITLE
fix(components): basePath-aware PDF assets, demo accessibility, and CountryFlag recovery

### DIFF
--- a/MULTI_COUNTRY_IMPACT_DATA_SOLUTION.md
+++ b/MULTI_COUNTRY_IMPACT_DATA_SOLUTION.md
@@ -1,238 +1,25 @@
-# Multi-Country Impact Data Solution
+# Multi-Country Impact Data: Current Status
 
-## Problem Statement
+## Summary
 
-Impact data (economic damage and wind intensity shading) was only loading for **one country at a time** (defaulting to Vanuatu). When users zoomed out to view all countries on the map, only Vanuatu showed the colored regional impact overlays, while Samoa, Tonga, and Cook Islands appeared without impact data.
+Regional impact overlays currently load in **single-country mode**. When `countryCode` is `null`, the current implementation falls back to **Vanuatu (`'VU'`)**.
 
-## Root Cause
+## Confirmed Behavior in This Repo
 
-The `useRegionalImpactsData` hook was designed to load data for a **single country** only:
-- When `countryCode` was `null`, it defaulted to `'VU'` (Vanuatu)
-- No mechanism existed to aggregate data from all countries
-- The system was architecturally single-country focused
+- `RegionalImpactsLayer` computes `effectiveCountry` as `countryCode ?? 'VU'`.
+- There is no `useRegionalImpactsData` hook in this repository.
+- There is no `loadAllCountriesRegionalImpacts` function in `src/utils/realDataLoader.ts`.
 
-## World-Class Solution Implemented
+## What This Means for Users
 
-### 1. **New Multi-Country Data Loader** (`loadAllCountriesRegionalImpacts`)
+- Selecting a specific country (`VU`, `WS`, `TO`, `CK`) loads that country's regional impact data.
+- Passing `countryCode={null}` does **not** aggregate all countries; it currently renders using Vanuatu as fallback.
 
-Created a new function in `/src/utils/realDataLoader.ts` that:
-- ✅ Loads regional impact data from **all 4 countries** in parallel (VU, WS, TO, CK)
-- ✅ Enriches each country's data with its regional summary data
-- ✅ Adds a `country_code` property to every feature for identification
-- ✅ Combines all features into a single unified GeoJSON FeatureCollection
-- ✅ Uses `Promise.allSettled` for fault tolerance (continues even if one country fails)
-- ✅ Provides detailed console logging for debugging
+## Notes for Future Multi-Country Support
 
-**Key Features:**
-```typescript
-export async function loadAllCountriesRegionalImpacts(
-  options: DataLoaderOptions = {}
-): Promise<GeoJSON.FeatureCollection>
-```
+If true all-country overlays are needed, implementation work is still required:
 
-- Parallel loading for maximum performance
-- Automatic enrichment with regional summary data (Total_Loss, Max_Wind_Gusts, etc.)
-- Graceful degradation if any country's data fails to load
-- Returns combined GeoJSON with all features from all countries
-
-### 2. **Enhanced Hook with Multi-Country Mode** (`useRegionalImpactsData`)
-
-Completely rewrote `/src/hooks/useRegionalImpactsData.ts` to support two modes:
-
-**Mode: ALL** (when `countryCode === null`)
-- Loads data for all countries using `loadAllCountriesRegionalImpacts()`
-- Caches with key `'ALL'` to avoid redundant loading
-- Perfect for global/multi-country map views
-
-**Mode: SINGLE** (when `countryCode` is specified)
-- Loads data for specific country (legacy behavior)
-- Caches per country code
-- Maintains backward compatibility
-
-**Smart Caching:**
-- Separate cache entries for `'ALL'` vs individual countries
-- Cache invalidation when switching between modes
-- No unnecessary re-fetching
-
-### 3. **Automatic Detection**
-
-The system now automatically:
-- Detects when users zoom out to see all countries
-- Loads combined multi-country data when `countryCode` is `null`
-- Shows impact data for **ALL 4 countries** simultaneously
-
-## Implementation Details
-
-### Files Modified
-
-1. **`/src/utils/realDataLoader.ts`**
-   - Added `loadAllCountriesRegionalImpacts()` function
-   - Exports the new function
-
-2. **`/src/hooks/useRegionalImpactsData.ts`**
-   - Complete rewrite with multi-country support
-   - Smart mode detection (`'ALL'` vs single country)
-   - Enhanced caching strategy
-
-3. **`/src/utils/index.ts`**
-   - Exported `loadAllCountriesRegionalImpacts` for use throughout the app
-
-### Data Structure
-
-Each feature in the combined GeoJSON now has:
-```json
-{
-  "type": "Feature",
-  "geometry": { ... },
-  "properties": {
-    "country_code": "WS",  // ← NEW: Identifies which country
-    "Region": "Apia Urban Area",
-    "Total_Loss": 12500000,
-    "Max_Wind_Gusts": 185,
-    "Damaged_Buildings": 2450,
-    "Population_Exposed_To_Any_Hazard": 38000,
-    ... // all other regional data
-  }
-}
-```
-
-### Performance Optimizations
-
-1. **Parallel Loading**: All 4 countries load simultaneously (not sequentially)
-2. **Smart Caching**: Data loaded once and cached per mode
-3. **Lazy Sector Data**: Sector-by-region data skipped in ALL mode (can be added later if needed)
-4. **Graceful Degradation**: Continues if one country fails
-
-## How It Works
-
-### User Experience Flow
-
-1. **User opens map** → Regional impacts layer initializes
-2. **Hook receives `countryCode`**:
-   - `null` → Triggers ALL mode → Loads all 4 countries
-   - `'VU'`/`'WS'`/`'TO'`/`'CK'` → Loads that specific country
-3. **Data loads in parallel** → Enriched → Combined → Rendered
-4. **Map shows colored regions** for all countries with economic damage and wind intensity
-
-### Console Output (for debugging)
-
-```
-🌍 [loadAllCountriesRegionalImpacts] Loading data for all countries...
-✅ Loaded 107 regions for VU
-✅ Loaded 45 regions for WS
-✅ Loaded 23 regions for TO
-✅ Loaded 15 regions for CK
-🎉 Combined 190 total regions from 4 countries
-```
-
-## Benefits of This Solution
-
-### ✅ World-Class Features
-
-1. **Complete Coverage** - All countries display impact data simultaneously
-2. **High Performance** - Parallel loading, smart caching
-3. **Fault Tolerant** - Continues even if one country's data fails
-4. **Backward Compatible** - Single-country view still works perfectly
-5. **Scalable** - Easy to add more countries in the future
-6. **Maintainable** - Clean separation of concerns
-7. **Well-Logged** - Comprehensive console logging for debugging
-
-### ✅ Production Ready
-
-- ✅ TypeScript type-safe
-- ✅ Error handling for network failures
-- ✅ AbortController support for cleanup
-- ✅ Memory efficient caching
-- ✅ Build verified (no compile errors)
-
-## Testing the Solution
-
-### To verify all countries show impact data:
-
-1. **Start the development server**: `npm run dev`
-2. **Navigate to the map view**
-3. **Zoom out to see multiple countries**
-4. **Check the browser console** for loading messages
-5. **Verify colored overlays appear** on all 4 countries
-
-### Expected Behavior
-
-- **Vanuatu** (VU): Purple/blue regional shading ✅
-- **Samoa** (WS): Purple/blue regional shading ✅
-- **Tonga** (TO): Purple/blue regional shading ✅
-- **Cook Islands** (CK): Purple/blue regional shading ✅
-
-Each region should show:
-- Economic damage (Total_Loss) - darker colors = higher damage
-- Wind intensity (Max_Wind_Gusts) - color intensity based on wind speed
-- Proper popups with all regional statistics
-
-## Future Enhancements (Optional)
-
-1. **Add multi-country sector data** - Currently skipped in ALL mode
-2. **Progressive loading** - Load visible countries first, others on demand
-3. **Country-level aggregation** - Show country-total statistics
-4. **Dynamic country selection** - Allow users to toggle countries on/off
-5. **IndexedDB caching** - Persist data across sessions
-
-## Technical Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    RegionalImpactsLayer                      │
-│                  (Renders map visualization)                 │
-└──────────────────────────┬──────────────────────────────────┘
-                           │ uses
-                           ▼
-┌─────────────────────────────────────────────────────────────┐
-│               useRegionalImpactsData Hook                    │
-│  ┌─────────────────┐           ┌──────────────────┐         │
-│  │   Single Mode   │           │    ALL Mode      │         │
-│  │  (country='VU') │           │  (country=null)  │         │
-│  └────────┬────────┘           └────────┬─────────┘         │
-└───────────┼─────────────────────────────┼───────────────────┘
-            │                             │
-            ▼                             ▼
-┌──────────────────────┐    ┌─────────────────────────────────┐
-│ loadRegionalImpacts  │    │loadAllCountriesRegionalImpacts  │
-│ (single country)     │    │  ┌────────────────────────┐     │
-└──────────────────────┘    │  │ Load VU in parallel    │     │
-                            │  │ Load WS in parallel    │     │
-                            │  │ Load TO in parallel    │     │
-                            │  │ Load CK in parallel    │     │
-                            │  └────────┬───────────────┘     │
-                            │           ▼                     │
-                            │  ┌────────────────────────┐     │
-                            │  │ Enrich each with       │     │
-                            │  │ regional summary data  │     │
-                            │  └────────┬───────────────┘     │
-                            │           ▼                     │
-                            │  ┌────────────────────────┐     │
-                            │  │ Add country_code prop  │     │
-                            │  └────────┬───────────────┘     │
-                            │           ▼                     │
-                            │  ┌────────────────────────┐     │
-                            │  │ Combine all features   │     │
-                            │  └────────────────────────┘     │
-                            └─────────────────────────────────┘
-```
-
-## Conclusion
-
-This solution provides a **world-class, production-ready implementation** that:
-- ✅ Solves the core problem (all countries show impact data)
-- ✅ Maintains high performance (parallel loading, caching)
-- ✅ Remains maintainable (clean code, type-safe)
-- ✅ Scales easily (add more countries with minimal changes)
-- ✅ Handles errors gracefully (fault-tolerant)
-
-The implementation follows React best practices, TypeScript conventions, and modern async/await patterns. It's ready for immediate production deployment.
-
----
-
-**Next Steps:**
-1. Deploy to production ✨
-2. Monitor console logs for any data loading issues
-3. Consider adding country-level aggregations if needed
-4. Optionally implement progressive loading for very large datasets
-
+1. Add a loader that fetches all supported countries and merges features.
+2. Add a data-access mode split (`single` vs `all`).
+3. Add cache keys for combined data vs per-country data.
+4. Update UI copy and guides only after code is implemented.

--- a/QUICK_START_MULTI_COUNTRY.md
+++ b/QUICK_START_MULTI_COUNTRY.md
@@ -1,315 +1,48 @@
-# Quick Start Guide: Multi-Country Impact Data
+# Quick Start: Regional Impact Data (Current Behavior)
 
-## ✅ Solution Overview
+## Current State
 
-The multi-country impact data solution is now **fully implemented and ready to use**. All 4 countries (Vanuatu, Samoa, Tonga, Cook Islands) will now display economic damage and wind intensity data on the map.
+The current map data flow is **single-country oriented**.
 
-## 🎯 How It Works
+- `countryCode='VU' | 'WS' | 'TO' | 'CK'` → loads that specific country.
+- `countryCode={null}` → currently falls back to **Vanuatu (`'VU'`)**.
 
-### Automatic Multi-Country Mode
+> This repository does not currently include an all-country aggregation mode.
 
-The system has **two modes**:
+## How to Use Today
 
-1. **Single Country Mode** - When `countryCode` is specified (e.g., `'VU'`, `'WS'`)
-   - Loads data for that specific country only
-   - Optimized for country-specific dashboards
-
-2. **ALL Countries Mode** - When `countryCode` is `null`
-   - Loads data for ALL 4 countries simultaneously
-   - Perfect for global/regional map views
-   - Automatically activated when viewing all countries
-
-### Current Implementation
-
-The solution works **immediately** in these scenarios:
-
-#### ✅ Already Working
-
-When the `RegionalImpactsLayer` component receives `countryCode={null}`, it automatically:
-```
-1. Detects ALL mode
-2. Loads data for VU, WS, TO, CK in parallel
-3. Enriches each with regional summary data
-4. Combines into single GeoJSON
-5. Renders colored overlays for all countries
-```
-
-## 🚀 Activating Multi-Country View
-
-### Option 1: Global Map View (Recommended)
-
-If you want a global dashboard showing all countries:
-
-**Create `/src/app/global/page.tsx`:**
-
-```typescript
-import DashboardView from '@/components/DashboardView';
-
-export default function GlobalPage() {
-  return (
-    <DashboardView
-      countryCode={null}  // ← This triggers ALL mode
-      allowCountrySwitch={true}
-      showLogout={false}
-    />
-  );
-}
-```
-
-**Update `/src/components/DashboardView.tsx`** to accept null:
-
-```typescript
-interface DashboardViewProps {
-  countryCode: CountryCode | null;  // ← Add | null
-  allowCountrySwitch?: boolean;
-  showLogout?: boolean;
-}
-```
-
-Then navigate to `/global` to see all countries with impact data!
-
-### Option 2: Modify Root Page
-
-Update `/src/app/page.tsx` to show global view by default:
-
-```typescript
-export default function RootPage() {
-  const tenantCountryCode = getTenantCountryCodeFromEnv();
-  if (tenantCountryCode) {
-    redirect(`/${CODE_TO_SLUG[tenantCountryCode]}`);
-  }
-
-  // NEW: Show global view instead of country selector
-  return (
-    <DashboardView
-      countryCode={null}
-      allowCountrySwitch={true}
-      showLogout={false}
-    />
-  );
-}
-```
-
-### Option 3: Programmatic Toggle
-
-Add a global/country toggle button in your UI:
-
-```typescript
-const [viewMode, setViewMode] = useState<'global' | 'country'>('country');
-const effectiveCountryCode = viewMode === 'global' ? null : selectedCountry;
-
-return (
-  <MapView
-    selectedCountry={effectiveCountryCode}
-    // ... other props
-  />
-);
-```
-
-## 🧪 Testing the Solution
-
-### 1. Check Console Logs
-
-When multi-country mode activates, you'll see:
-
-```
-🌐 [useRegionalImpactsData] Loading data for ALL countries...
-✅ Loaded 107 regions for VU
-✅ Loaded 45 regions for WS
-✅ Loaded 23 regions for TO
-✅ Loaded 15 regions for CK
-🎉 Combined 190 total regions from 4 countries
-📊 [useRegionalImpactsData] Data loaded for ALL:
-  features: 190
-  hasLossField: true
-  hasWindField: true
-```
-
-### 2. Visual Verification
-
-All countries should show:
-- ✅ Purple/blue economic damage shading
-- ✅ Wind intensity color gradients
-- ✅ Interactive popups with regional data
-- ✅ Proper country boundaries
-
-### 3. Performance Metrics
-
-Expected load times:
-- **Single country**: ~500-1000ms
-- **All countries**: ~1500-2500ms (parallel loading)
-- **Cache hit**: <50ms
-
-## 🎨 Customization Examples
-
-### Example 1: Global Crisis Dashboard
-
-```typescript
-// Show all countries with high-severity filter
-<DashboardView
-  countryCode={null}
-  allowCountrySwitch={false}
-  showLogout={false}
-/>
-```
-
-### Example 2: Regional Comparison View
-
-```typescript
-// Compare Samoa and Tonga
-const pacificCountries: CountryCode[] = ['WS', 'TO'];
-
-// In your custom hook:
-const loadPacificData = async () => {
-  const results = await Promise.all(
-    pacificCountries.map(code => 
-      loadRegionalImpacts({ countryCode: code })
-    )
-  );
-  
-  return combinedFeatureCollection(results);
-};
-```
-
-### Example 3: Dynamic Country Filter
-
-```typescript
-const [visibleCountries, setVisibleCountries] = useState<CountryCode[]>([
-  'VU', 'WS', 'TO', 'CK'
-]);
-
-// Filter data based on selection
-const filteredData = useMemo(() => {
-  if (!allCountriesData) return null;
-  
-  return {
-    ...allCountriesData,
-    features: allCountriesData.features.filter(f => 
-      visibleCountries.includes(f.properties.country_code)
-    )
-  };
-}, [allCountriesData, visibleCountries]);
-```
-
-## 📊 Data Structure Reference
-
-Each feature in ALL mode has:
-
-```json
-{
-  "type": "Feature",
-  "properties": {
-    "country_code": "TO",               // ← NEW: Country identifier
-    "Region": "Vava'u",
-    "Total_Loss": 5400000,
-    "Max_Wind_Gusts": 195,
-    "Damaged_Buildings": 890,
-    "Population_Exposed_To_Any_Hazard": 15000,
-    "Total_Population": 18500,
-    "Number_Exposed_Buildings": 1200
-  },
-  "geometry": { ... }
-}
-```
-
-## 🔧 Troubleshooting
-
-### Issue: Data not loading
-
-**Check:**
-1. Console for error messages
-2. Network tab for failed requests
-3. Data files exist in `/public/{country}/`
-
-**Solution:**
-```bash
-# Verify data files exist
-ls -la public/vanuatu/regional-impacts.geojson
-ls -la public/samoa/regional-impacts.geojson
-ls -la public/tonga/regional-impacts.geojson
-ls -la public/cook-islands/regional-impacts.geojson
-```
-
-### Issue: Only Vanuatu shows data
-
-**Check:**
-```typescript
-// Verify countryCode is actually null
-console.log('countryCode:', countryCode);  // Should be null
-
-// Check if data loaded
-console.log('Features:', data?.features?.length);  // Should be ~190
-```
-
-**Solution:**
-Ensure `countryCode={null}` is passed to RegionalImpactsLayer
-
-### Issue: Performance slow
-
-**Check:**
-- Browser DevTools > Network tab
-- Check for sequential loading (should be parallel)
-
-**Solution:**
-Increase browser cache or add service worker
-
-## 📈 Performance Optimization
-
-### Recommended Settings
-
-```typescript
-// In next.config.ts
-export default {
-  async headers() {
-    return [
-      {
-        source: '/:country/regional-impacts.geojson',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable'
-          }
-        ]
-      }
-    ];
-  }
-};
-```
-
-### Progressive Loading (Future Enhancement)
-
-```typescript
-// Load visible countries first, others on-demand
-const loadVisibleCountries = async (bounds: Bounds) => {
-  const visibleCountries = getCountriesInBounds(bounds);
-  return loadMultipleCountries(visibleCountries);
-};
-```
-
-## ✨ Next Steps
-
-1. **Activate global view** using one of the options above
-2. **Test** that all 4 countries display impact data
-3. **Customize** based on your specific needs
-4. **Monitor** performance in production
-
----
-
-**Need Help?**
-
-Check the detailed documentation in:
-- [MULTI_COUNTRY_IMPACT_DATA_SOLUTION.md](./MULTI_COUNTRY_IMPACT_DATA_SOLUTION.md)
-
-**Quick Test:**
+### 1) Run the app
 
 ```bash
-# Start dev server
 npm run dev
-
-# Open browser
-# Navigate to your global view route
-# Check console for "🎉 Combined 190 total regions from 4 countries"
-# Verify all countries show colored overlays
 ```
 
-🎉 **Your multi-country impact data solution is ready!**
+### 2) Test country-specific overlays
+
+Set a concrete country code where `MapView` / `RegionalImpactsLayer` is used:
+
+```tsx
+<MapView selectedCountry="WS" mapStyle="loss" ... />
+```
+
+Then verify:
+- Samoa regions render shading in `loss` mode.
+- Switching to `wind` changes the shading metric.
+- Popups show region-level impact values.
+
+### 3) Understand `null` behavior
+
+If you set:
+
+```tsx
+<MapView selectedCountry={null} ... />
+```
+
+the current implementation resolves to Vanuatu as fallback (not combined VU/WS/TO/CK).
+
+## Recommended Next Work (if all-country mode is required)
+
+1. Implement a combined data loader for all supported countries.
+2. Introduce explicit `all` vs `single` loading mode.
+3. Add cache and UI behavior for combined datasets.
+4. Update docs after implementation lands.

--- a/TEST_CHUNKED_ENCODING_FIX.md
+++ b/TEST_CHUNKED_ENCODING_FIX.md
@@ -14,7 +14,7 @@
 
 ### 1. **Start Dev Server**
 ```bash
-cd /home/kishank/Partner2
+cd <repo-root>
 npm run dev
 ```
 

--- a/src/components/CountryFlag.tsx
+++ b/src/components/CountryFlag.tsx
@@ -33,8 +33,10 @@ export default function CountryFlag({
   'aria-label': ariaLabel,
 }: CountryFlagProps) {
   const countryName = COUNTRIES[countryCode].name;
-  const [hasLoadError, setHasLoadError] = useState(false);
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
   const flagSrc = useMemo(() => `${BASE_PATH}${FLAG_IMAGE_PATHS[countryCode]}`, [countryCode]);
+  const hasLoadError = failedSrc === flagSrc;
+
   const fallbackLabel = countryName
     .split(/\s+/)
     .map(part => part[0] ?? '')
@@ -85,7 +87,7 @@ export default function CountryFlag({
       className={className}
       width={24}
       height={18}
-      onError={() => setHasLoadError(true)}
+      onError={() => setFailedSrc(flagSrc)}
       style={{
         ...sharedStyle,
         objectFit: 'cover',

--- a/src/components/ExportButtons.tsx
+++ b/src/components/ExportButtons.tsx
@@ -22,7 +22,11 @@ const normalizeBasePath = (basePath?: string) => {
   return withLeadingSlash.replace(/\/+$/, '');
 };
 
-const BASE_PATH = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
+const DEFAULT_PRODUCTION_BASE_PATH = '/partner2';
+const resolvedBasePath =
+  process.env.NEXT_PUBLIC_BASE_PATH ??
+  (process.env.NODE_ENV === 'production' ? DEFAULT_PRODUCTION_BASE_PATH : undefined);
+const BASE_PATH = normalizeBasePath(resolvedBasePath);
 
 // Helper to create asset URLs with correct base path
 const pdfAsset = (path: string) => {
@@ -407,11 +411,11 @@ export default function ExportButtons({
         WS: '/pdf-assets/country-headers/DashBoard_Header_Samoa.png',
       };
       const countryFlagMap: Record<string, string> = {
-        VU: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Vanuatu.svg.png'),
-        CK: pdfAsset('/pdf-assets/Country_Flags/2000px-Flag_of_the_Cook_Islands.svg.png'),
-        TO: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Tonga.svg.png'),
-        WS: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Samoa.svg.png'),
-        FJ: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Fiji.svg.png'),
+        VU: '/pdf-assets/Country_Flags/Flag_of_Vanuatu.svg.png',
+        CK: '/pdf-assets/Country_Flags/2000px-Flag_of_the_Cook_Islands.svg.png',
+        TO: '/pdf-assets/Country_Flags/Flag_of_Tonga.svg.png',
+        WS: '/pdf-assets/Country_Flags/Flag_of_Samoa.svg.png',
+        FJ: '/pdf-assets/Country_Flags/Flag_of_Fiji.svg.png',
       };
       const countryHeaderPath = countryCode ? countryHeaderMap[countryCode] : undefined;
       const countryFlagPath = countryCode ? countryFlagMap[countryCode] : undefined;
@@ -617,11 +621,11 @@ export default function ExportButtons({
         WS: '/pdf-assets/country-headers/DashBoard_Header_Samoa.png',
       };
       const countryFlagMap: Record<string, string> = {
-        VU: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Vanuatu.svg.png'),
-        CK: pdfAsset('/pdf-assets/Country_Flags/2000px-Flag_of_the_Cook_Islands.svg.png'),
-        TO: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Tonga.svg.png'),
-        WS: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Samoa.svg.png'),
-        FJ: pdfAsset('/pdf-assets/Country_Flags/Flag_of_Fiji.svg.png'),
+        VU: '/pdf-assets/Country_Flags/Flag_of_Vanuatu.svg.png',
+        CK: '/pdf-assets/Country_Flags/2000px-Flag_of_the_Cook_Islands.svg.png',
+        TO: '/pdf-assets/Country_Flags/Flag_of_Tonga.svg.png',
+        WS: '/pdf-assets/Country_Flags/Flag_of_Samoa.svg.png',
+        FJ: '/pdf-assets/Country_Flags/Flag_of_Fiji.svg.png',
       };
       const countryHeaderPath = countryCode ? countryHeaderMap[countryCode] : undefined;
       const countryFlagPath = countryCode ? countryFlagMap[countryCode] : undefined;

--- a/src/components/ExportButtons.tsx
+++ b/src/components/ExportButtons.tsx
@@ -14,10 +14,23 @@ import {
   getPdfKeyFigureIconLayout,
 } from './pdfTemplateConfig';
 
-const BASE_PATH = process.env.NODE_ENV === 'production' ? '/partner2' : '';
+const normalizeBasePath = (basePath?: string) => {
+  if (!basePath || basePath === '/') {
+    return '';
+  }
+  const withLeadingSlash = basePath.startsWith('/') ? basePath : `/${basePath}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+const BASE_PATH = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
 
 // Helper to create asset URLs with correct base path
-const pdfAsset = (path: string) => `${BASE_PATH}${path}`;
+const pdfAsset = (path: string) => {
+  if (!path) return path;
+  if (/^(?:[a-z]+:)?\/\//i.test(path)) return path;
+  if (!path.startsWith('/')) return path;
+  return `${BASE_PATH}${path}`;
+};
 
 // OCHA colour palette (RGB tuples)
 const OCHA_BLUE: [number, number, number] = [0, 124, 224];
@@ -246,8 +259,9 @@ export default function ExportButtons({
         }
   ): Promise<string | undefined> => {
     try {
+      const normalizedPath = pdfAsset(path);
       // URL-encode the path to handle spaces and special characters
-      const encodedPath = path
+      const encodedPath = normalizedPath
         .split('/')
         .map(segment => encodeURIComponent(segment))
         .join('/');

--- a/src/components/MultiCountryImpactDemo.tsx
+++ b/src/components/MultiCountryImpactDemo.tsx
@@ -1,13 +1,13 @@
 /**
  * Multi-Country Impact Data Demo Component
  *
- * This component demonstrates the new multi-country impact data loading capability.
- * Drop this into any page to test that all countries display economic damage and wind intensity.
+ * This component demonstrates regional impact data loading for Pacific countries.
+ * When countryCode is null, it defaults to Vanuatu for testing purposes.
  *
  * USAGE:
  * 1. Create a new route: /src/app/demo/page.tsx
  * 2. Import and render this component
- * 3. Navigate to /demo to see all 4 countries with impact data
+ * 3. Navigate to /demo to test country-specific impact data display
  */
 
 'use client';

--- a/src/components/MultiCountryImpactDemo.tsx
+++ b/src/components/MultiCountryImpactDemo.tsx
@@ -1,9 +1,9 @@
 /**
  * Multi-Country Impact Data Demo Component
- * 
+ *
  * This component demonstrates the new multi-country impact data loading capability.
  * Drop this into any page to test that all countries display economic damage and wind intensity.
- * 
+ *
  * USAGE:
  * 1. Create a new route: /src/app/demo/page.tsx
  * 2. Import and render this component
@@ -39,24 +39,28 @@ export default function MultiCountryImpactDemo() {
       {/* Control Panel */}
       <div className="bg-slate-900 border-b border-slate-700 p-4">
         <div className="max-w-7xl mx-auto">
-          <h1 className="text-2xl font-bold text-white mb-4">
-            Multi-Country Impact Data Demo
-          </h1>
-          
+          <h1 className="text-2xl font-bold text-white mb-4">Multi-Country Impact Data Demo</h1>
+
           <div className="flex flex-wrap gap-4 items-center">
             {/* Country Selector */}
             <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">
+              <label
+                htmlFor="view-mode-select"
+                className="block text-sm font-medium text-slate-300 mb-2"
+              >
                 View Mode
               </label>
               <select
+                id="view-mode-select"
                 value={selectedCountry ?? 'ALL'}
-                onChange={(e) => setSelectedCountry(
-                  e.target.value === 'ALL' ? null : e.target.value as CountryCode
-                )}
+                onChange={e =>
+                  setSelectedCountry(
+                    e.target.value === 'ALL' ? null : (e.target.value as CountryCode)
+                  )
+                }
                 className="bg-slate-800 text-white px-4 py-2 rounded-lg border border-slate-600 hover:border-blue-500 transition-colors"
               >
-                <option value="ALL">🌍 All Countries (Multi-Country Mode)</option>
+                <option value="ALL">🌍 All Countries (overview mode)</option>
                 <option value="VU">🇻🇺 Vanuatu</option>
                 <option value="WS">🇼🇸 Samoa</option>
                 <option value="TO">🇹🇴 Tonga</option>
@@ -66,12 +70,16 @@ export default function MultiCountryImpactDemo() {
 
             {/* Map Style Selector */}
             <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">
+              <label
+                htmlFor="display-mode-select"
+                className="block text-sm font-medium text-slate-300 mb-2"
+              >
                 Display Mode
               </label>
               <select
+                id="display-mode-select"
                 value={mapStyle}
-                onChange={(e) => setMapStyle(e.target.value as 'loss' | 'wind')}
+                onChange={e => setMapStyle(e.target.value as 'loss' | 'wind')}
                 className="bg-slate-800 text-white px-4 py-2 rounded-lg border border-slate-600 hover:border-blue-500 transition-colors"
               >
                 <option value="loss">💰 Economic Damage</option>
@@ -89,10 +97,9 @@ export default function MultiCountryImpactDemo() {
                   </span>
                 </div>
                 <div className="text-xs text-slate-500 mt-1">
-                  {selectedCountry === null 
-                    ? 'Loading impact data for Vanuatu, Samoa, Tonga, and Cook Islands'
-                    : `Loading impact data for ${selectedCountry} only`
-                  }
+                  {selectedCountry === null
+                    ? 'Overview mode currently falls back to Vanuatu regional impact overlays'
+                    : `Loading impact data for ${selectedCountry} only`}
                 </div>
               </div>
             </div>
@@ -101,9 +108,10 @@ export default function MultiCountryImpactDemo() {
           {/* Instructions */}
           <div className="mt-4 p-3 bg-blue-900/20 border border-blue-500/30 rounded-lg">
             <p className="text-sm text-blue-300">
-              <strong>💡 Tip:</strong> Select "All Countries" to see the multi-country mode in action. 
-              All 4 countries should display colored regional overlays showing economic damage or wind intensity.
-              Check your browser console for detailed loading logs.
+              <strong>💡 Tip:</strong> &quot;All Countries&quot; gives a regional map overview, but
+              current impact shading behavior falls back to Vanuatu when no country is selected.
+              Choose a specific country to validate country-specific overlays and check browser
+              console logs for data-loading details.
             </p>
           </div>
         </div>
@@ -161,43 +169,37 @@ export default function MultiCountryImpactDemo() {
 
 /**
  * HOW TO USE THIS DEMO:
- * 
+ *
  * 1. Create /src/app/demo/page.tsx with:
- * 
+ *
  *    import MultiCountryImpactDemo from '@/components/MultiCountryImpactDemo';
- *    
+ *
  *    export default function DemoPage() {
  *      return <MultiCountryImpactDemo />;
  *    }
- * 
+ *
  * 2. Navigate to http://localhost:3000/demo
- * 
- * 3. Check console for these messages:
- *    🌐 [useRegionalImpactsData] Loading data for ALL countries...
- *    ✅ Loaded 107 regions for VU
- *    ✅ Loaded 45 regions for WS
- *    ✅ Loaded 23 regions for TO
- *    ✅ Loaded 15 regions for CK
- *    🎉 Combined 190 total regions from 4 countries
- * 
- * 4. Verify all 4 countries show colored overlays
- * 
+ *
+ * 3. Check console for country-specific loading messages and verify selected-country overlays.
+ *
+ * 4. Verify the selected country shows colored overlays
+ *
  * 5. Click regions to see popups with:
  *    - Economic damage (Total_Loss)
  *    - Wind intensity (Max_Wind_Gusts)
  *    - Buildings damaged
  *    - Population affected
- * 
+ *
  * TROUBLESHOOTING:
- * 
+ *
  * - If only Vanuatu shows data:
  *   → Check that selectedCountry is actually null in console
  *   → Verify data files exist in public/samoa, public/tonga, public/cook-islands
- * 
+ *
  * - If console shows errors:
  *   → Check network tab for failed requests
  *   → Verify file paths match COUNTRY_DATA_FILE_OVERRIDES
- * 
+ *
  * - If performance is slow:
  *   → Check that loading is parallel (all 4 at once, not sequential)
  *   → Enable caching in next.config.ts


### PR DESCRIPTION
### Motivation
- Prevent PDF asset 404s when the app is hosted under a Next.js `basePath` (e.g. `/partner2`) and make demo/docs reflect runtime behavior.
- Improve demo accessibility and UX so testers are not misled by documentation that claims unsupported multi-country aggregation.
- Ensure `CountryFlag` recovers when switching countries after an image load failure.

### Description
- Centralized basePath normalization in `ExportButtons` by reading `NEXT_PUBLIC_BASE_PATH` and applying a `pdfAsset()` normalization to all absolute PDF asset fetches, and used the normalized path inside `fetchAssetDataUrl` to avoid production 404s (changes in `src/components/ExportButtons.tsx`).
- Improved `MultiCountryImpactDemo` accessibility by adding `id`/`htmlFor` associations for selects and updated copy/messages to accurately state that `null` currently falls back to Vanuatu rather than loading all countries (changes in `src/components/MultiCountryImpactDemo.tsx`).
- Fixed persistent flag load error state by tracking the failed image `src` and only showing the fallback when the currently-active `flagSrc` actually failed, allowing recovery when switching countries (changes in `src/components/CountryFlag.tsx`).
- Replaced overly-optimistic multi-country docs with an accurate current-state note and updated quick-start/troubleshooting docs and the test guide to remove developer-specific absolute paths (updates to `MULTI_COUNTRY_IMPACT_DATA_SOLUTION.md`, `QUICK_START_MULTI_COUNTRY.md`, and `TEST_CHUNKED_ENCODING_FIX.md`).

### Testing
- Ran targeted lints: `npm run lint -- src/components/ExportButtons.tsx src/components/MultiCountryImpactDemo.tsx src/components/CountryFlag.tsx`, which completed successfully with warnings only and no errors.
- Ran formatting: `npx prettier --write src/components/MultiCountryImpactDemo.tsx`, which completed successfully.
- Pre-commit checks (type-check via `tsc --noEmit`, `eslint`, and `prettier --check`) passed during the commit process.  No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6444786a0832386e1cddf7b2a65de)